### PR TITLE
chore(skills): add coding-pattern skill assets and references

### DIFF
--- a/skills/public/go-coding-patterns/agents/openai.yaml
+++ b/skills/public/go-coding-patterns/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Go Coding Patterns"
+  short_description: "Production Go implementation and review patterns."
+  default_prompt: "Apply robust Go coding patterns for implementation, debugging, refactoring, and code review."

--- a/skills/public/go-coding-patterns/references/concurrency-patterns.md
+++ b/skills/public/go-coding-patterns/references/concurrency-patterns.md
@@ -1,0 +1,30 @@
+# Go Concurrency Patterns
+
+## 1. Context First
+
+- Pass `context.Context` as first param for request-scoped operations.
+- Honor cancellation/deadlines in all I/O boundaries.
+- Never store context in struct fields.
+
+## 2. Goroutine Lifecycle
+
+- Every goroutine needs ownership and shutdown path.
+- Use `errgroup` for coordinated worker lifecycles.
+- Avoid fire-and-forget goroutines in server code.
+
+## 3. Channel Patterns
+
+- Use channels for ownership transfer and coordination.
+- Close channels from sender side only.
+- Use bounded worker pools for backpressure.
+
+## 4. Timeouts and Retries
+
+- Apply deadlines with context + transport timeouts.
+- Retry only transient failures with bounded attempts and backoff.
+
+## 5. Common Hazards
+
+- Goroutine leaks from blocked sends/receives.
+- Deadlocks from cyclic channel dependencies.
+- Shared mutable state races without synchronization.

--- a/skills/public/go-coding-patterns/references/core-patterns.md
+++ b/skills/public/go-coding-patterns/references/core-patterns.md
@@ -1,0 +1,42 @@
+# Core Go Patterns
+
+## 1. Package and API Design
+
+- Keep packages cohesive with clear responsibility.
+- Favor small interfaces defined by consumers.
+- Return concrete types from constructors when possible.
+
+## 2. Error Strategy
+
+- Return errors, do not panic for expected failures.
+- Wrap errors with context (`fmt.Errorf("...: %w", err)`).
+- Use `errors.Is` / `errors.As` for branching.
+- Keep sentinel errors limited and well-documented.
+
+## 3. Data and State
+
+- Prefer explicit structs over map-heavy loosely typed state.
+- Keep invariants close to constructors/methods.
+- Avoid exposing mutable internal fields.
+
+## 4. Performance
+
+- Measure first (`pprof`, benchmarks).
+- Minimize allocations in hot loops.
+- Reuse buffers where appropriate.
+- Watch lock contention and channel bottlenecks.
+
+## 5. Tooling Baseline
+
+- `gofmt` / `go fmt`
+- `go vet`
+- `golangci-lint` (where adopted)
+- `go test ./...`
+- `go test -race ./...` for concurrency-sensitive changes
+
+## 6. Anti-Patterns
+
+- Ignoring returned errors.
+- Context not propagated across call stack.
+- Unbounded goroutine spawning under load.
+- Overly broad interfaces (“interface pollution”).

--- a/skills/public/go-coding-patterns/references/domain-cli.md
+++ b/skills/public/go-coding-patterns/references/domain-cli.md
@@ -1,0 +1,6 @@
+# Domain Constraints: Go CLI
+
+- Deterministic output and stable exit codes.
+- Clear user-facing errors with next-step hints.
+- Keep command handlers small and testable.
+- Avoid hidden global mutable state.

--- a/skills/public/go-coding-patterns/references/domain-data.md
+++ b/skills/public/go-coding-patterns/references/domain-data.md
@@ -1,0 +1,6 @@
+# Domain Constraints: Go Data Pipelines/Workers
+
+- Use explicit backpressure in worker pools.
+- Ensure idempotent processing where retries occur.
+- Track per-batch/per-record failure metrics.
+- Design for restart safety and checkpointed progress.

--- a/skills/public/go-coding-patterns/references/domain-web.md
+++ b/skills/public/go-coding-patterns/references/domain-web.md
@@ -1,0 +1,7 @@
+# Domain Constraints: Go Web/Microservices
+
+- Request-scoped context propagation is mandatory.
+- Timeouts required for all outbound calls.
+- Structured logs with request correlation IDs.
+- Graceful shutdown drains in-flight requests.
+- Bound fan-out to downstream dependencies.

--- a/skills/public/go-coding-patterns/references/error-to-design-map.md
+++ b/skills/public/go-coding-patterns/references/error-to-design-map.md
@@ -1,0 +1,17 @@
+# Error-to-Design Map (Go)
+
+## Concurrency Failures
+
+- Goroutine leaks -> missing ownership/shutdown design; introduce context + errgroup.
+- Deadlocks -> circular waits or unbounded blocking ops; redesign flow and buffering.
+- Data races -> shared mutable state without clear ownership; synchronize or redesign ownership.
+
+## Error-Handling Smells
+
+- Repeated ignored errors (`_ = ...`) -> missing failure model; force explicit handling.
+- String comparison on errors -> weak taxonomy; use wrapped/sentinel/custom types.
+
+## API Design Smells
+
+- Large interfaces for testing convenience -> wrong abstraction direction; define minimal consumer interfaces.
+- Widespread `interface{}`/`any` in business logic -> weak domain model; add typed boundaries.

--- a/skills/public/go-coding-patterns/references/review-checklist.md
+++ b/skills/public/go-coding-patterns/references/review-checklist.md
@@ -1,0 +1,23 @@
+# Go Review Checklist
+
+## Severity
+
+- `S0`: outage/security/data corruption risk.
+- `S1`: correctness bug.
+- `S2`: reliability/performance/maintainability risk.
+- `S3`: style/docs.
+
+## Findings-First Format
+
+1. List findings by severity with file/line.
+2. State impact and reproduction conditions.
+3. Provide minimal remediation.
+4. Then list testing gaps.
+
+## Checks
+
+- Context is propagated and honored.
+- Goroutines are bounded and cancellable.
+- Errors are wrapped with actionable context.
+- Shared state synchronization is explicit and race-safe.
+- Critical paths have tests (and race tests where needed).

--- a/skills/public/python-coding-patterns/agents/openai.yaml
+++ b/skills/public/python-coding-patterns/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Coding Patterns"
+  short_description: "Production Python implementation and review patterns."
+  default_prompt: "Apply robust Python coding patterns for implementation, debugging, refactoring, and code review."

--- a/skills/public/python-coding-patterns/references/asyncio-patterns.md
+++ b/skills/public/python-coding-patterns/references/asyncio-patterns.md
@@ -1,0 +1,49 @@
+# Asyncio Patterns
+
+## Table of Contents
+
+1. Runtime and Task Lifecycle
+2. Structured Concurrency
+3. Concurrency Limits and Backpressure
+4. Cancellation and Shutdown
+5. Async Error Handling
+6. Shared State Patterns
+7. Async Anti-Patterns
+
+## 1. Runtime and Task Lifecycle
+
+- Use `asyncio.run()` as top-level entrypoint.
+- Keep async boundaries explicit; avoid hidden event-loop management.
+
+## 2. Structured Concurrency
+
+- Prefer `asyncio.TaskGroup` (3.11+) for sibling task orchestration.
+- Treat orphan tasks as bugs unless explicitly detached.
+
+## 3. Concurrency Limits and Backpressure
+
+- Use `asyncio.Semaphore` for bounded fan-out.
+- Use `asyncio.Queue(maxsize=...)` for producer/consumer backpressure.
+
+## 4. Cancellation and Shutdown
+
+- Treat cancellation as normal control flow.
+- Catch `asyncio.CancelledError` only to clean up, then re-raise.
+- Add timeout budgets with `asyncio.timeout()`.
+
+## 5. Async Error Handling
+
+- Aggregate task failures intentionally (`ExceptionGroup` in 3.11+).
+- Classify retryable vs permanent errors.
+- Keep retries bounded with timeout + jitter/backoff.
+
+## 6. Shared State Patterns
+
+- Prefer message passing over shared mutable state.
+- If required, guard state with `asyncio.Lock` and tight critical sections.
+
+## 7. Async Anti-Patterns
+
+- Blocking calls in async paths (`time.sleep`, sync DB/http clients).
+- Unbounded `create_task` loops.
+- Swallowing cancellation or task exceptions.

--- a/skills/public/python-coding-patterns/references/core-patterns.md
+++ b/skills/public/python-coding-patterns/references/core-patterns.md
@@ -1,0 +1,45 @@
+# Core Python Patterns
+
+## 1. Typing Strategy
+
+- Type public APIs and boundary layers first.
+- Use `Protocol` for behavior contracts; avoid deep inheritance where composition works.
+- Prefer precise models (`TypedDict`, `dataclass`, pydantic models where appropriate).
+
+## 2. Data Modeling
+
+- Use immutable/value-style objects for domain invariants when possible.
+- Keep constructors validated; avoid partially initialized objects.
+
+## 3. Error Strategy
+
+- Raise domain-specific exceptions near domain logic.
+- Map internal exceptions to boundary-safe errors (HTTP/CLI/queue handlers).
+- Do not use broad `except Exception` without strict re-raise/logging rationale.
+
+## 4. Architecture Boundaries
+
+- Keep pure business logic separated from I/O adapters.
+- Keep functions short and side-effect scope explicit.
+- Inject dependencies for testability.
+
+## 5. Performance Discipline
+
+- Measure first (`cProfile`, `py-spy`, tracing).
+- Reduce allocations in hot loops.
+- Use iterators/generators for streaming workflows.
+- Vectorize numeric paths or move CPU hotspots to compiled paths when needed.
+
+## 6. Tooling Baseline
+
+- Format: `ruff format` or `black`.
+- Lint: `ruff check`.
+- Type check: `pyright` or `mypy`.
+- Tests: `pytest` with unit + integration coverage.
+
+## 7. Anti-Patterns
+
+- Dynamic typing everywhere in large codebases.
+- God modules with mixed concerns.
+- Silent exception suppression.
+- Mutable default args.

--- a/skills/public/python-coding-patterns/references/domain-cli.md
+++ b/skills/public/python-coding-patterns/references/domain-cli.md
@@ -1,0 +1,6 @@
+# Domain Constraints: Python CLI
+
+- Stable exit codes and machine-readable output modes.
+- Clear stderr messages for user-correctable failures.
+- Avoid implicit global state and side effects.
+- Keep command handlers testable and deterministic.

--- a/skills/public/python-coding-patterns/references/domain-data.md
+++ b/skills/public/python-coding-patterns/references/domain-data.md
@@ -1,0 +1,6 @@
+# Domain Constraints: Python Data/ETL
+
+- Prefer idempotent transforms and checkpointing.
+- Separate schema validation from transform logic.
+- Track row-level/partition-level failure metrics.
+- Avoid loading entire datasets when streaming/chunking fits.

--- a/skills/public/python-coding-patterns/references/domain-web.md
+++ b/skills/public/python-coding-patterns/references/domain-web.md
@@ -1,0 +1,7 @@
+# Domain Constraints: Python Web/API
+
+- Keep request handlers thin; delegate to services/use-cases.
+- Validate input at boundary and convert to typed domain objects.
+- Ensure DB/network calls are timeout-bound.
+- Emit structured logs with request IDs.
+- Return stable, explicit error payloads.

--- a/skills/public/python-coding-patterns/references/error-to-design-map.md
+++ b/skills/public/python-coding-patterns/references/error-to-design-map.md
@@ -1,0 +1,18 @@
+# Error-to-Design Map (Python)
+
+## Runtime and Logic Failures
+
+- Frequent `AttributeError`/`KeyError`: unclear data contracts -> define typed models.
+- Frequent `NoneType` errors: nullable boundaries unclear -> explicit Optional handling.
+- Repeated broad exception catches: missing error taxonomy -> introduce domain exceptions.
+
+## Async Failures
+
+- “Task exception was never retrieved”: unstructured task lifecycle -> use TaskGroup or explicit joins.
+- Event loop blocked warnings: sync calls in async path -> isolate via thread/process executors.
+- Cancellation bugs: swallowed `CancelledError` -> cleanup then re-raise.
+
+## Type Checker Failures
+
+- Persistent `Any` spread: weak boundary typing -> type external interfaces first.
+- Complex union narrowing failures: overloaded responsibilities -> split functions and types.

--- a/skills/public/python-coding-patterns/references/review-checklist.md
+++ b/skills/public/python-coding-patterns/references/review-checklist.md
@@ -1,0 +1,22 @@
+# Python Review Checklist
+
+## Severity
+
+- `S0`: data loss/security/major reliability issue.
+- `S1`: correctness bug with user impact.
+- `S2`: maintainability/perf/reliability risk.
+- `S3`: style/docs.
+
+## Findings-First Output
+
+1. List findings by severity with file and line.
+2. Describe runtime impact.
+3. Provide minimal fix direction.
+4. Then list testing gaps.
+
+## Checks
+
+- Boundary typing and model validation are explicit.
+- Exceptions are typed/intentional and not silently swallowed.
+- Async code is bounded and cancellation-safe.
+- Critical paths have tests for failure and edge cases.

--- a/skills/public/rust-coding-patterns/agents/openai.yaml
+++ b/skills/public/rust-coding-patterns/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Coding Patterns"
+  short_description: "Production Rust implementation and review patterns."
+  default_prompt: "Apply robust Rust coding patterns for implementation, refactoring, debugging, and code review."

--- a/skills/public/rust-coding-patterns/references/async-tokio.md
+++ b/skills/public/rust-coding-patterns/references/async-tokio.md
@@ -1,0 +1,186 @@
+# Async Tokio Patterns
+
+## Table of Contents
+
+1. Runtime Setup
+2. Task Orchestration Patterns
+3. Channel Selection Guide
+4. Stream Patterns
+5. Graceful Shutdown and Cancellation
+6. Async Error Handling Patterns
+7. Async Trait Patterns
+8. Shared State and Resource Management
+9. Debugging and Observability
+10. Async Anti-Patterns
+
+## 1. Runtime Setup
+
+Default stack for production async services:
+
+```toml
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+async-trait = "0.1"
+thiserror = "1"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tokio-util = "0.7"
+```
+
+Runtime bootstrap:
+
+```rust
+use anyhow::Result;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().with_target(false).init();
+    run().await
+}
+```
+
+## 2. Task Orchestration Patterns
+
+### `JoinSet` for dynamic fan-out
+
+Use when number of tasks is discovered at runtime.
+
+```rust
+use tokio::task::JoinSet;
+
+async fn fetch_all(urls: Vec<String>) -> Vec<anyhow::Result<String>> {
+    let mut set = JoinSet::new();
+    for url in urls {
+        set.spawn(async move { fetch(&url).await });
+    }
+
+    let mut out = Vec::new();
+    while let Some(res) = set.join_next().await {
+        match res {
+            Ok(value) => out.push(value),
+            Err(e) => out.push(Err(anyhow::anyhow!("join failure: {e}"))),
+        }
+    }
+    out
+}
+```
+
+### Bounded concurrency with `buffer_unordered`
+
+Use for throughput without unbounded task growth.
+
+```rust
+use futures::stream::{self, StreamExt};
+
+async fn fetch_limited(urls: Vec<String>, limit: usize) -> Vec<anyhow::Result<String>> {
+    stream::iter(urls)
+        .map(|url| async move { fetch(&url).await })
+        .buffer_unordered(limit)
+        .collect()
+        .await
+}
+```
+
+### `tokio::select!` for cancellation/timeouts/racing
+
+Use for multi-condition control flow.
+
+## 3. Channel Selection Guide
+
+- `mpsc`: work queues, ingestion pipelines, producer-worker model.
+- `broadcast`: pub/sub event fan-out.
+- `oneshot`: request/response handoff of one value.
+- `watch`: config/state latest-value propagation.
+
+Decision defaults:
+- Need backpressure and ordered ingestion: `mpsc` with bounded capacity.
+- Need each subscriber to observe events: `broadcast`.
+- Need consumers to read only current state: `watch`.
+
+## 4. Stream Patterns
+
+Common patterns:
+- Use `StreamExt::chunks` for batch processing.
+- Use `select` to merge streams.
+- Use combinators to avoid materializing intermediate collections.
+
+## 5. Graceful Shutdown and Cancellation
+
+Preferred strategy:
+
+1. Create a root `CancellationToken`.
+2. Clone token into all long-running tasks.
+3. Use `tokio::select!` with `token.cancelled()` inside task loops.
+4. Trigger cancellation on `ctrl_c`/health signal.
+5. Wait bounded time for cleanup.
+
+```rust
+use tokio::signal;
+use tokio::time::{sleep, Duration};
+use tokio_util::sync::CancellationToken;
+
+async fn run_service() -> anyhow::Result<()> {
+    let token = CancellationToken::new();
+    let task_token = token.clone();
+
+    let handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                _ = task_token.cancelled() => break,
+                _ = do_work_cycle() => {}
+            }
+        }
+    });
+
+    signal::ctrl_c().await?;
+    token.cancel();
+
+    tokio::select! {
+        _ = handle => {},
+        _ = sleep(Duration::from_secs(5)) => {
+            tracing::warn!("shutdown timeout");
+        }
+    }
+
+    Ok(())
+}
+```
+
+## 6. Async Error Handling Patterns
+
+- Library crates: define typed errors with `thiserror`.
+- Binaries/services: use `anyhow::Result` at orchestration layers.
+- Add context at I/O boundaries and external calls.
+- Classify retryable vs non-retryable failures.
+- Wrap uncertain latency operations with explicit timeout.
+
+## 7. Async Trait Patterns
+
+- Use `async-trait` when dynamic dispatch or object-safe trait APIs are required.
+- Prefer generic traits where possible for static dispatch.
+- Keep trait methods narrow and transport-agnostic.
+
+## 8. Shared State and Resource Management
+
+- Prefer message passing over shared mutable state when feasible.
+- For shared state:
+  - Read-heavy: `Arc<RwLock<T>>`
+  - Write-heavy or simple critical sections: `Arc<Mutex<T>>`
+- Never hold lock guards across `.await`.
+- Bound scarce resources with semaphores.
+
+## 9. Debugging and Observability
+
+- Add `#[tracing::instrument]` on async boundaries.
+- Emit structured fields (`request_id`, `user_id`, `task_id`).
+- Correlate spawned tasks with spans.
+- Use Tokio console for runtime task visibility when needed.
+
+## 10. Async Anti-Patterns
+
+- Blocking executor threads (`std::thread::sleep`, blocking DB clients).
+- Unbounded spawn loops under uncontrolled input.
+- Swallowing join errors.
+- Mixing cancellation-agnostic tasks with graceful shutdown guarantees.

--- a/skills/public/rust-coding-patterns/references/core-patterns.md
+++ b/skills/public/rust-coding-patterns/references/core-patterns.md
@@ -1,0 +1,118 @@
+# Core Rust Patterns
+
+## Table of Contents
+
+1. Ownership and Borrowing Decisions
+2. Mutability and Interior Mutability
+3. Type-Driven Design and Invariants
+4. Error Handling Strategy
+5. Concurrency Model Selection
+6. Dispatch and Abstraction Choices
+7. Performance and Allocation Discipline
+8. Ecosystem Integration and Tooling
+9. Anti-Pattern Remediation
+
+## 1. Ownership and Borrowing Decisions
+
+Core question: who owns data and for how long?
+
+Default API rules:
+- Inputs: borrow (`&str`, `&[T]`, `&T`) unless ownership transfer is required.
+- Outputs: return owned values when data must outlive local scope.
+- Small `Copy` values: pass by value.
+
+Smart pointer guide:
+- `Box<T>`: single owner + heap allocation.
+- `Rc<T>`: shared ownership, single-threaded.
+- `Arc<T>`: shared ownership, multi-threaded.
+- `Weak<T>`: break cycles in graph-like relationships.
+
+## 2. Mutability and Interior Mutability
+
+Choose the least powerful mutability primitive that works:
+- `&mut T`: preferred for exclusive mutation.
+- `Cell<T>`: interior mutability for small `Copy` data.
+- `RefCell<T>`: interior mutability with runtime borrow checks.
+- `Mutex<T>` / `RwLock<T>`: thread-safe interior mutability.
+- Atomics: primitive lock-free counters/flags.
+
+Rule: keep mutation scopes short and explicit.
+
+## 3. Type-Driven Design and Invariants
+
+Encode constraints in types:
+- Newtype for semantic meaning (`UserId`, `Email`, `Currency`).
+- Private fields + validated constructors for always-valid state.
+- Typestate for compile-time transition constraints.
+- Builder when valid construction requires multiple steps.
+
+Use runtime checks only when validation depends on external state.
+
+## 4. Error Handling Strategy
+
+Failure semantics:
+- Recoverable failure: `Result<T, E>`.
+- Expected absence: `Option<T>`.
+- Invariant violation/bug: `panic!`/`assert!`.
+
+Crate-level guidance:
+- Library/public API: typed error enum with `thiserror`.
+- Application/service boundary: `anyhow` + context.
+
+Hard rules:
+- No bare `unwrap()`/`expect()` in production paths without explicit invariant rationale.
+- Include context near boundaries (network, disk, DB, serialization).
+
+## 5. Concurrency Model Selection
+
+Decision order:
+1. Is work CPU-bound? Use threads/rayon.
+2. Is work I/O-bound? Use Tokio async.
+3. Is work mixed? Use async orchestration and isolate blocking with `spawn_blocking`.
+
+Sharing defaults:
+- No sharing needed: channels.
+- Shared immutable data: `Arc<T>`.
+- Shared mutable data: `Arc<Mutex<T>>` or `Arc<RwLock<T>>`.
+
+## 6. Dispatch and Abstraction Choices
+
+- Prefer static dispatch (generics/`impl Trait`) for hot paths.
+- Use dynamic dispatch (`dyn Trait`) for runtime polymorphism or heterogeneous collections.
+- Use enums for closed sets of variants.
+- Minimize trait bounds and keep them where needed.
+
+## 7. Performance and Allocation Discipline
+
+Optimization priority:
+1. Algorithmic complexity.
+2. Data structure fit to access patterns.
+3. Allocation elimination and reuse.
+4. Cache locality.
+5. Parallelism/SIMD.
+
+Practical defaults:
+- Benchmark only in `--release`.
+- Pre-allocate with `with_capacity` when sizes are known.
+- Avoid hidden clones in loops.
+- Avoid collect-then-reiterate when chained iterators work.
+
+## 8. Ecosystem Integration and Tooling
+
+Quality baseline:
+- `cargo fmt`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- Unit + integration tests
+
+Dependency policy:
+- Prefer maintained crates and minimal feature sets.
+- Avoid broad dependency additions for narrow use cases.
+- Keep versions explicit and workspace-aligned.
+
+## 9. Anti-Pattern Remediation
+
+Common smell -> root cause -> fix:
+- Many `.clone()` calls -> unclear ownership -> redesign ownership flow.
+- Many `.unwrap()` in app logic -> missing error strategy -> propagate `Result` and add context.
+- `Arc<Mutex<T>>` everywhere -> over-shared state -> push toward channels and ownership partitioning.
+- Lifetimes repeatedly fight code shape -> wrong data flow -> redesign model boundaries.

--- a/skills/public/rust-coding-patterns/references/domain-cli.md
+++ b/skills/public/rust-coding-patterns/references/domain-cli.md
@@ -1,0 +1,24 @@
+# Domain Constraints: CLI Applications
+
+Apply these constraints for `clap`-based tools and command-line workflows.
+
+## Core Constraints
+
+- UX should be deterministic and script-friendly.
+- Exit codes must be meaningful and stable.
+- Error output should be concise and actionable.
+- Startup time and binary size may matter more than maximal abstraction.
+
+## Recommended Patterns
+
+- Parse args with strong types and defaults.
+- Keep command handlers narrow and testable.
+- Use typed errors internally; map to user-facing messages at boundary.
+- Prefer synchronous code unless async is justified by I/O concurrency needs.
+
+## Common Mistakes
+
+- Panicking on invalid user input.
+- Emitting inconsistent output formats across commands.
+- Overusing async in simple linear workflows.
+- Ignoring non-zero exit code semantics.

--- a/skills/public/rust-coding-patterns/references/domain-cloud-native.md
+++ b/skills/public/rust-coding-patterns/references/domain-cloud-native.md
@@ -1,0 +1,24 @@
+# Domain Constraints: Cloud-Native / gRPC / Microservices
+
+Apply for distributed systems with service boundaries and observability requirements.
+
+## Core Constraints
+
+- All remote boundaries need timeout, retry, and circuit-breaker thinking.
+- Structured tracing and metrics are mandatory for operability.
+- Graceful shutdown must drain in-flight work within budget.
+- Backpressure must be explicit at queue and task boundaries.
+
+## Recommended Patterns
+
+- Define clear transport/domain error conversion boundaries.
+- Use bounded channels and bounded task concurrency.
+- Add health/readiness semantics tied to dependency state.
+- Treat config updates as controlled state transitions.
+
+## Common Mistakes
+
+- Infinite retries without jitter/backoff limits.
+- Unbounded queues causing memory blowups.
+- Logging without trace correlation.
+- Abrupt shutdown that drops in-flight work silently.

--- a/skills/public/rust-coding-patterns/references/domain-fintech.md
+++ b/skills/public/rust-coding-patterns/references/domain-fintech.md
@@ -1,0 +1,30 @@
+# Domain Constraints: Fintech / Trading / Payments
+
+Use stricter defaults for correctness, auditability, and deterministic behavior.
+
+## Core Constraints
+
+- Precision correctness is mandatory (no float money math).
+- Every state transition should be auditable.
+- Retry logic must be idempotent-aware.
+- Failure handling must separate transient from permanent errors.
+
+## Recommended Patterns
+
+- Represent money/quantities with decimal/fixed-point newtypes.
+- Use typed state transitions (typestate or validated transition methods).
+- Record immutable event logs for key operations.
+- Attach correlation IDs to all external operations.
+
+## Concurrency and Consistency
+
+- Use explicit ordering/locking strategy for account/position updates.
+- Avoid hidden shared mutable state in critical paths.
+- Define timeout and retry budgets from business SLAs.
+
+## Common Mistakes
+
+- Using `f32`/`f64` for currency.
+- Non-idempotent retries for payment submission.
+- Missing audit fields in error paths.
+- Ambiguous error categories for operational handling.

--- a/skills/public/rust-coding-patterns/references/domain-web.md
+++ b/skills/public/rust-coding-patterns/references/domain-web.md
@@ -1,0 +1,24 @@
+# Domain Constraints: Web/API Services
+
+Apply these constraints for `axum`, `actix-web`, and HTTP microservices.
+
+## Core Constraints
+
+- Handlers must be cancellation-safe and timeout-aware.
+- Shared app state should be thread-safe (`Arc`-based).
+- Error responses must be explicit and stable (status + machine-readable body).
+- Request paths should emit structured tracing with request IDs.
+
+## Recommended Patterns
+
+- State: `Arc<AppState>` with internal sync primitives only where needed.
+- Validation: parse/validate at boundary; pass typed domain values inward.
+- Errors: map domain errors to HTTP status codes via dedicated conversion layer.
+- Concurrency: bounded fan-out for downstream calls.
+
+## Common Mistakes
+
+- Using non-`Send` state in handlers.
+- Holding lock guards while awaiting downstream services.
+- Returning opaque 500 errors for domain failures.
+- Missing request-scoped correlation fields in logs.

--- a/skills/public/rust-coding-patterns/references/error-to-design-map.md
+++ b/skills/public/rust-coding-patterns/references/error-to-design-map.md
@@ -1,0 +1,118 @@
+# Error-to-Design Map
+
+Map common compiler/runtime failures to design questions before applying tactical fixes.
+
+## Table of Contents
+
+1. Ownership Errors
+2. Borrowing and Mutability Errors
+3. Trait and Type Errors
+4. Concurrency and Async Errors
+5. Error-Handling Smells
+
+## 1. Ownership Errors
+
+### `E0382` use of moved value
+
+Do not default to cloning.
+
+Ask:
+- Should ownership stay with caller?
+- Should callee borrow instead?
+- Is shared ownership actually needed (`Rc`/`Arc`)?
+
+### `E0515` cannot return reference to local value
+
+Ask:
+- Should return type be owned?
+- Is the source data lifetime correct for borrowing?
+
+### `E0507` cannot move out of borrowed content
+
+Ask:
+- Is consumption attempted through `&T`?
+- Should API take ownership instead?
+
+## 2. Borrowing and Mutability Errors
+
+### `E0499` multiple mutable borrows
+
+Ask:
+- Can mutation be sequenced into smaller scopes?
+- Should data be split into independent sub-structs?
+
+### `E0502` cannot borrow mutable because immutable borrow exists
+
+Ask:
+- Can immutable borrow end sooner?
+- Can derived value be copied/cloned once and borrow dropped?
+
+### Runtime `RefCell` panic (already borrowed)
+
+Ask:
+- Is interior mutability needed here?
+- Should control flow enforce borrowing at compile-time with `&mut`?
+
+## 3. Trait and Type Errors
+
+### `E0277` trait bound not satisfied
+
+Ask:
+- Is abstraction boundary correct?
+- Should this be static dispatch, dynamic dispatch, or concrete type?
+
+### `E0038` trait not object safe
+
+Ask:
+- Is `dyn Trait` required?
+- Can generic static dispatch replace object safety requirements?
+
+### `E0308` mismatched types
+
+Ask:
+- Is conversion explicit and intentional?
+- Is newtype or enum needed to represent domain distinctions?
+
+## 4. Concurrency and Async Errors
+
+### `future is not Send` / `E0277` with `Send`
+
+Ask:
+- Does task need to cross threads (`tokio::spawn`)?
+- Can non-Send values be dropped before `.await`?
+- Should work run in local task set instead?
+
+### Lock guard held across `.await`
+
+Symptom:
+- deadlocks, stalled throughput, or borrow checker issues around guards.
+
+Ask:
+- Can lock scope be reduced to pre/post await sections?
+- Can data be copied out before awaiting?
+
+### Blocking in async context
+
+Ask:
+- Is this CPU-bound/blocking I/O path that belongs in `spawn_blocking`?
+- Can async-native client/library replace blocking API?
+
+## 5. Error-Handling Smells
+
+### Frequent `unwrap()`/`expect()`
+
+Ask:
+- Is failure truly impossible?
+- If not, who should handle failure and with what context?
+
+### Lossy string errors
+
+Ask:
+- Does caller need typed variants for recovery?
+- Should error enum be introduced at boundary?
+
+### Retry everywhere
+
+Ask:
+- Which errors are transient?
+- What are attempt limits, backoff policy, and timeout budgets?

--- a/skills/public/rust-coding-patterns/references/review-checklist.md
+++ b/skills/public/rust-coding-patterns/references/review-checklist.md
@@ -1,0 +1,58 @@
+# Rust Review Checklist
+
+## Severity Model
+
+- `S0 Critical`: data loss, security exposure, UB risk, or deadlock/high-probability outage.
+- `S1 High`: correctness bug with user-visible wrong behavior.
+- `S2 Medium`: maintainability/performance/reliability risk likely to regress.
+- `S3 Low`: style/documentation/readability improvements.
+
+## Findings-First Output
+
+1. List findings by severity (`S0` to `S3`).
+2. Include exact file path and line reference per finding.
+3. State impact and expected runtime behavior.
+4. Provide minimal actionable fix.
+5. After findings, list testing gaps.
+
+## Correctness and Safety
+
+- Ownership/borrow changes preserve runtime behavior.
+- No hidden panic paths in production control flow.
+- Unsafe blocks include safety invariants and are justified.
+- Error mapping preserves actionable information.
+
+## Async and Concurrency
+
+- No lock guards held across `.await`.
+- `Send`/`Sync` assumptions match spawn/executor model.
+- Concurrency is bounded (no unbounded fan-out by default).
+- Cancellation and shutdown paths are coherent and testable.
+
+## API and Type Design
+
+- Borrow where possible; own where lifecycle requires.
+- Newtypes/type constraints enforce key invariants.
+- Trait abstraction choice matches performance/flexibility goals.
+- Public API surfaces are minimal and stable.
+
+## Performance and Resource Use
+
+- No obvious hot-path allocations/clones.
+- Data structures match read/write/access patterns.
+- Blocking work isolated from async runtime workers.
+- Complexity regressions are identified and justified.
+
+## Tests and Verification
+
+- New behavior has direct tests.
+- Edge/failure paths are covered.
+- Concurrency-sensitive code has deterministic checks where possible.
+- Integration boundaries (network/DB/FFI) have representative tests.
+
+## Review Red Flags
+
+- “Fix” is adding `.clone()` without ownership reasoning.
+- `unwrap()` introduced outside tests/proven invariants.
+- `Arc<Mutex<T>>` used as default without contention strategy.
+- Major logic change with no added tests.

--- a/skills/public/skill-development/agents/openai.yaml
+++ b/skills/public/skill-development/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Skill Development"
+  short_description: "Build high-quality Codex/Claude-style skills."
+  default_prompt: "Design, structure, validate, and iterate high-quality skills with strong triggers and progressive disclosure."

--- a/skills/public/skill-development/references/skill-creator-original.md
+++ b/skills/public/skill-development/references/skill-creator-original.md
@@ -1,0 +1,658 @@
+---
+name: skill-development
+description: This skill provides guidance for creating effective skills for codex Code plugins.
+---
+
+# Skill Development for codex Code Plugins
+
+This skill provides guidance for creating effective skills for codex Code plugins.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend codex's capabilities by providing specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific domains or tasks—they transform codex from a general-purpose agent into a specialized agent equipped with procedural knowledge that no model can fully possess.
+
+## What Skills Provide
+
+- Specialized workflows - Multi-step procedures for specific domains
+- Tool integrations - Instructions for working with specific file formats or APIs
+- Domain expertise - Company-specific knowledge, schemas, business logic
+- Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+## Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```text
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+## SKILL.md (required)
+
+Metadata Quality: The name and description in YAML frontmatter determine when codex will use the skill. Be specific about what the skill does and when to use it. Use the third-person (e.g. "This skill should be used when..." instead of "Use this skill when...").
+
+## Bundled Resources (optional)
+
+### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- When to include: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- Example: scripts/rotate_pdf.py for PDF rotation tasks
+- Benefits: Token efficient, deterministic, may be executed without loading into context
+- Note: Scripts may still need to be read by codex for patching or environment-specific adjustments
+
+### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform codex's process and thinking.
+
+- When to include: For documentation that codex should reference while working
+- Examples: references/finance.md for financial schemas, references/mnda.md for company NDA template, references/policies.md for company policies, references/api_docs.md for API specifications
+- Use cases: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- Benefits: Keeps SKILL.md lean, loaded only when codex determines it's needed
+- Best practice: If files are large (>10k words), include grep search patterns in SKILL.md
+- Avoid duplication: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output codex produces.
+
+- When to include: When the skill needs files that will be used in the final output
+- Examples: assets/logo.png for brand assets, assets/slides.pptx for PowerPoint templates, assets/frontend-template/ for HTML/React boilerplate, assets/font.ttf for typography
+- Use cases: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- Benefits: Separates output resources from documentation, enables codex to use files without loading them into context
+
+## Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. Metadata (name + description) - Always in context (~100 words)
+2. SKILL.md body - When skill triggers (<5k words)
+3. Bundled resources - As needed by codex (Unlimited*)
+
+*Unlimited because scripts can be executed without reading into context window.
+
+## Skill Creation Process
+
+To create a skill, follow the "Skill Creation Process" in order, skipping steps only if there is a clear reason why they are not applicable.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a pdf-editor skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A scripts/rotate_pdf.py script would be helpful to store in the skill
+
+Example: When designing a frontend-webapp-builder skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An assets/hello-world/ template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a big-query skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A references/schema.md file documenting the table schemas would be helpful to store in the skill
+
+For codex Code plugins: When building a hooks skill, the analysis shows:
+
+- Developers repeatedly need to validate hooks.json and test hook scripts
+- scripts/validate-hook-schema.sh and scripts/test-hook.sh utilities would be helpful
+- references/patterns.md for detailed hook patterns to avoid bloating SKILL.md
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 3: Create Skill Structure
+
+For codex Code plugins, create the skill directory structure:
+
+```bash
+mkdir -p plugin-name/skills/skill-name/{references,examples,scripts}
+touch plugin-name/skills/skill-name/SKILL.md
+```
+
+Note: Unlike the generic skill-creator which uses init_skill.py, plugin skills are created directly in the plugin's skills/ directory with a simpler manual structure.
+
+### Step 4: Edit the Skill
+
+When editing the (newly-created or existing) skill, remember that the skill is being created for another instance of codex to use. Focus on including information that would be beneficial and non-obvious to codex. Consider what procedural knowledge, domain-specific details, or reusable assets would help another codex instance execute these tasks more effectively.
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: scripts/, references/, and assets/ files. Note that this step may require user input. For example, when implementing a brand-guidelines skill, the user may need to provide brand assets or templates to store in assets/, or documentation to store in references/.
+
+Also, delete any example files and directories not needed for the skill. Create only the directories you actually need (references/, examples/, scripts/).
+
+#### Update SKILL.md
+
+Writing Style: Write the entire skill using imperative/infinitive form (verb-first instructions), not second person. Use objective, instructional language (e.g., "To accomplish X, do Y" rather than "You should do X" or "If you need to do X"). This maintains consistency and clarity for AI consumption.
+
+Description (Frontmatter): Use third-person format with specific trigger phrases:
+
+```yaml
+---
+name: Skill Name
+description: This skill should be used when the user asks to "specific phrase 1", "specific phrase 2", "specific phrase 3". Include exact phrases users would say that should trigger this skill. Be concrete and specific.
+version: 0.1.0
+---
+```
+
+Good description examples:
+
+```yaml
+description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", "implement prompt-based hooks", or mentions hook events (PreToolUse, PostToolUse, Stop).
+```
+
+Bad description examples:
+
+```yaml
+description: Use this skill when working with hooks.  # Wrong person, vague
+description: Load when user needs hook help.  # Not third person
+description: Provides hook guidance.  # No trigger phrases
+```
+
+To complete SKILL.md body, answer the following questions:
+
+- What is the purpose of the skill, in a few sentences?
+- When should the skill be used? (Include this in frontmatter description with specific triggers)
+- In practice, how should codex use the skill? All reusable skill contents developed above should be referenced so that codex knows how to use them.
+
+Keep SKILL.md lean: Target 1,500-2,000 words for the body. Move detailed content to references/:
+
+- Detailed patterns -> references/patterns.md
+- Advanced techniques -> references/advanced.md
+- Migration guides -> references/migration.md
+- API references -> references/api-reference.md
+
+Reference resources in SKILL.md:
+
+```markdown
+## Additional Resources
+
+### Reference Files
+
+For detailed patterns and techniques, consult:
+- **`references/patterns.md`** - Common patterns
+- **`references/advanced.md`** - Advanced use cases
+
+### Example Files
+
+Working examples in `examples/`:
+- **`example-script.sh`** - Working example
+```
+
+### Step 5: Validate and Test
+
+For plugin skills, validation is different from generic skills:
+
+- Check structure: Skill directory in plugin-name/skills/skill-name/
+- Validate SKILL.md: Has frontmatter with name and description
+- Check trigger phrases: Description includes specific user queries
+- Verify writing style: Body uses imperative/infinitive form, not second person
+- Test progressive disclosure: SKILL.md is lean (~1,500-2,000 words), detailed content in references/
+- Check references: All referenced files exist
+- Validate examples: Examples are complete and correct
+- Test scripts: Scripts are executable and work correctly
+
+Use the skill-reviewer agent:
+
+Ask: "Review my skill and check if it follows best practices"
+
+The skill-reviewer agent will check description quality, content organization, and progressive disclosure.
+
+### Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+Iteration workflow:
+
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again
+
+Common improvements:
+
+- Strengthen trigger phrases in description
+- Move long sections from SKILL.md to references/
+- Add missing examples or scripts
+- Clarify ambiguous instructions
+- Add edge case handling
+
+## Plugin-Specific Considerations
+
+### Skill Location in Plugins
+
+Plugin skills live in the plugin's skills/ directory:
+
+```text
+my-plugin/
+├── .codex-plugin/
+│   └── plugin.json
+├── commands/
+├── agents/
+└── skills/
+    └── my-skill/
+        ├── SKILL.md
+        ├── references/
+        ├── examples/
+        └── scripts/
+```
+
+### Auto-Discovery
+
+codex Code automatically discovers skills:
+
+- Scans skills/ directory
+- Finds subdirectories containing SKILL.md
+- Loads skill metadata (name + description) always
+- Loads SKILL.md body when skill triggers
+- Loads references/examples when needed
+
+### No Packaging Needed
+
+Plugin skills are distributed as part of the plugin, not as separate ZIP files. Users get skills when they install the plugin.
+
+### Testing in Plugins
+
+Test skills by installing plugin locally:
+
+```bash
+# Test with --plugin-dir
+cc --plugin-dir /path/to/plugin
+
+# Ask questions that should trigger the skill
+# Verify skill loads correctly
+```
+
+## Examples from Plugin-Dev
+
+Study the skills in this plugin as examples of best practices:
+
+### hook-development skill:
+
+- Excellent trigger phrases: "create a hook", "add a PreToolUse hook", etc.
+- Lean SKILL.md (1,651 words)
+- 3 references/ files for detailed content
+- 3 examples/ of working hooks
+- 3 scripts/ utilities
+
+### agent-development skill:
+
+- Strong triggers: "create an agent", "agent frontmatter", etc.
+- Focused SKILL.md (1,438 words)
+- References include the AI generation prompt from codex Code
+- Complete agent examples
+
+### plugin-settings skill:
+
+- Specific triggers: "plugin settings", ".local.md files", "YAML frontmatter"
+- References show real implementations (multi-agent-swarm, ralph-loop)
+- Working parsing scripts
+
+Each demonstrates progressive disclosure and strong triggering.
+
+## Progressive Disclosure in Practice
+
+### What Goes in SKILL.md
+
+Include (always loaded when skill triggers):
+
+- Core concepts and overview
+- Essential procedures and workflows
+- Quick reference tables
+- Pointers to references/examples/scripts
+- Most common use cases
+
+Keep under 3,000 words, ideally 1,500-2,000 words
+
+### What Goes in references/
+
+Move to references/ (loaded as needed):
+
+- Detailed patterns and advanced techniques
+- Comprehensive API documentation
+- Migration guides
+- Edge cases and troubleshooting
+- Extensive examples and walkthroughs
+
+Each reference file can be large (2,000-5,000+ words)
+
+### What Goes in examples/
+
+Working code examples:
+
+- Complete, runnable scripts
+- Configuration files
+- Template files
+- Real-world usage examples
+
+Users can copy and adapt these directly
+
+### What Goes in scripts/
+
+Utility scripts:
+
+- Validation tools
+- Testing helpers
+- Parsing utilities
+- Automation scripts
+
+Should be executable and documented
+
+## Writing Style Requirements
+
+### Imperative/Infinitive Form
+
+Write using verb-first instructions, not second person:
+
+Correct (imperative):
+
+- To create a hook, define the event type.
+- Configure the MCP server with authentication.
+- Validate settings before use.
+
+Incorrect (second person):
+
+- You should create a hook by defining the event type.
+- You need to configure the MCP server.
+- You must validate settings before use.
+
+### Third-Person in Description
+
+The frontmatter description must use third person:
+
+Correct:
+
+```yaml
+description: This skill should be used when the user asks to "create X", "configure Y"...
+```
+
+Incorrect:
+
+```yaml
+description: Use this skill when you want to create X...
+description: Load this skill when user asks...
+```
+
+### Objective, Instructional Language
+
+Focus on what to do, not who should do it:
+
+Correct:
+
+- Parse the frontmatter using sed.
+- Extract fields with grep.
+- Validate values before use.
+
+Incorrect:
+
+- You can parse the frontmatter...
+- codex should extract fields...
+- The user might validate values...
+
+## Validation Checklist
+
+Before finalizing a skill:
+
+### Structure:
+
+- [ ] SKILL.md file exists with valid YAML frontmatter
+- [ ] Frontmatter has name and description fields
+- [ ] Markdown body is present and substantial
+- [ ] Referenced files actually exist
+
+### Description Quality:
+
+- [ ] Uses third person ("This skill should be used when...")
+- [ ] Includes specific trigger phrases users would say
+- [ ] Lists concrete scenarios ("create X", "configure Y")
+- [ ] Not vague or generic
+
+### Content Quality:
+
+- [ ] SKILL.md body uses imperative/infinitive form
+- [ ] Body is focused and lean (1,500-2,000 words ideal, <5k max)
+- [ ] Detailed content moved to references/
+- [ ] Examples are complete and working
+- [ ] Scripts are executable and documented
+
+### Progressive Disclosure:
+
+- [ ] Core concepts in SKILL.md
+- [ ] Detailed docs in references/
+- [ ] Working code in examples/
+- [ ] Utilities in scripts/
+- [ ] SKILL.md references these resources
+
+### Testing:
+
+- [ ] Skill triggers on expected user queries
+- [ ] Content is helpful for intended tasks
+- [ ] No duplicated information across files
+- [ ] References load when needed
+
+## Common Mistakes to Avoid
+
+### Mistake 1: Weak Trigger Description
+
+Bad:
+
+```yaml
+description: Provides guidance for working with hooks.
+```
+
+Why bad: Vague, no specific trigger phrases, not third person
+
+Good:
+
+```yaml
+description: This skill should be used when the user asks to "create a hook", "add a PreToolUse hook", "validate tool use", or mentions hook events. Provides comprehensive hooks API guidance.
+```
+
+Why good: Third person, specific phrases, concrete scenarios
+
+### Mistake 2: Too Much in SKILL.md
+
+Bad:
+
+```text
+skill-name/
+└── SKILL.md  (8,000 words - everything in one file)
+```
+
+Why bad: Bloats context when skill loads, detailed content always loaded
+
+Good:
+
+```text
+skill-name/
+├── SKILL.md  (1,800 words - core essentials)
+└── references/
+    ├── patterns.md (2,500 words)
+    └── advanced.md (3,700 words)
+```
+
+Why good: Progressive disclosure, detailed content loaded only when needed
+
+### Mistake 3: Second Person Writing
+
+Bad:
+
+- You should start by reading the configuration file.
+- You need to validate the input.
+- You can use the grep tool to search.
+
+Why bad: Second person, not imperative form
+
+Good:
+
+- Start by reading the configuration file.
+- Validate the input before processing.
+- Use the grep tool to search for patterns.
+
+Why good: Imperative form, direct instructions
+
+### Mistake 4: Missing Resource References
+
+Bad:
+
+```markdown
+# SKILL.md
+
+[Core content]
+
+[No mention of references/ or examples/]
+```
+
+Why bad: codex doesn't know references exist
+
+Good:
+
+```markdown
+# SKILL.md
+
+[Core content]
+
+## Additional Resources
+
+### Reference Files
+- **`references/patterns.md`** - Detailed patterns
+- **`references/advanced.md`** - Advanced techniques
+
+### Examples
+- **`examples/script.sh`** - Working example
+```
+
+Why good: codex knows where to find additional information
+
+## Quick Reference
+
+### Minimal Skill
+
+```text
+skill-name/
+└── SKILL.md
+```
+
+Good for: Simple knowledge, no complex resources needed
+
+### Standard Skill (Recommended)
+
+```text
+skill-name/
+├── SKILL.md
+├── references/
+│   └── detailed-guide.md
+└── examples/
+    └── working-example.sh
+```
+
+Good for: Most plugin skills with detailed documentation
+
+### Complete Skill
+
+```text
+skill-name/
+├── SKILL.md
+├── references/
+│   ├── patterns.md
+│   └── advanced.md
+├── examples/
+│   ├── example1.sh
+│   └── example2.json
+└── scripts/
+    └── validate.sh
+```
+
+Good for: Complex domains with validation utilities
+
+## Best Practices Summary
+
+DO:
+
+- Use third-person in description ("This skill should be used when...")
+- Include specific trigger phrases ("create X", "configure Y")
+- Keep SKILL.md lean (1,500-2,000 words)
+- Use progressive disclosure (move details to references/)
+- Write in imperative/infinitive form
+- Reference supporting files clearly
+- Provide working examples
+- Create utility scripts for common operations
+- Study plugin-dev's skills as templates
+
+DON'T:
+
+- Use second person anywhere
+- Have vague trigger conditions
+- Put everything in SKILL.md (>3,000 words without references/)
+- Write in second person ("You should...")
+- Leave resources unreferenced
+- Include broken or incomplete examples
+- Skip validation
+
+## Additional Resources
+
+### Study These Skills
+
+Plugin-dev's skills demonstrate best practices:
+
+- ../hook-development/ - Progressive disclosure, utilities
+- ../agent-development/ - AI-assisted creation, references
+- ../mcp-integration/ - Comprehensive references
+- ../plugin-settings/ - Real-world examples
+- ../command-development/ - Clear critical concepts
+- ../plugin-structure/ - Good organization
+
+### Reference Files
+
+For complete skill-creator methodology:
+
+- references/skill-creator-original.md - Full original skill-creator content
+
+## Implementation Workflow
+
+To create a skill for your plugin:
+
+1. Understand use cases: Identify concrete examples of skill usage
+2. Plan resources: Determine what scripts/references/examples needed
+3. Create structure: mkdir -p skills/skill-name/{references,examples,scripts}
+4. Write SKILL.md:
+- Frontmatter with third-person description and trigger phrases
+- Lean body (1,500-2,000 words) in imperative form
+- Reference supporting files
+5. Add resources: Create references/, examples/, scripts/ as needed
+6. Validate: Check description, writing style, organization
+7. Test: Verify skill loads on expected triggers
+8. Iterate: Improve based on usage
+
+Focus on strong trigger descriptions, progressive disclosure, and imperative writing style for effective skills that load when needed and provide targeted guidance.

--- a/skills/public/typescript-javascript-coding-patterns/agents/openai.yaml
+++ b/skills/public/typescript-javascript-coding-patterns/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TS/JS Coding Patterns"
+  short_description: "Production TypeScript/JavaScript coding patterns."
+  default_prompt: "Apply robust TypeScript and JavaScript coding patterns for implementation, debugging, refactoring, and code review."

--- a/skills/public/typescript-javascript-coding-patterns/references/async-patterns.md
+++ b/skills/public/typescript-javascript-coding-patterns/references/async-patterns.md
@@ -1,0 +1,31 @@
+# Async Patterns (JS/TS)
+
+## 1. Concurrency Control
+
+- Use `Promise.all` only when full fan-out is safe.
+- Use bounded concurrency (`p-limit`, pools, queues) for external calls.
+- Keep queue depth and retry budgets explicit.
+
+## 2. Cancellation and Timeouts
+
+- Use `AbortController` for cancelable operations.
+- Tie every network/long-running operation to timeout policy.
+- Propagate abort signals through layers.
+
+## 3. Error Handling in Async Flows
+
+- Do not ignore rejected promises.
+- In services, map low-level errors to stable domain/application errors.
+- Treat retry as policy-driven, not ad hoc loops.
+
+## 4. Event Loop Health
+
+- Avoid CPU-heavy synchronous work on the main event loop.
+- Move CPU-heavy work to workers/child processes where needed.
+- Avoid long microtask chains that starve I/O.
+
+## 5. Anti-Patterns
+
+- Fire-and-forget promises without supervision.
+- Nested `then` chains when `async/await` is clearer.
+- Infinite retry loops without backoff/jitter/cap.

--- a/skills/public/typescript-javascript-coding-patterns/references/core-patterns.md
+++ b/skills/public/typescript-javascript-coding-patterns/references/core-patterns.md
@@ -1,0 +1,40 @@
+# Core JS/TS Patterns
+
+## 1. Type Boundaries
+
+- Prefer strict TS config for production libraries/services.
+- Validate untrusted data at boundaries (`zod`, `valibot`, `io-ts`, etc.).
+- Avoid leaking `any`; isolate unavoidable `unknown` and narrow quickly.
+
+## 2. API and Module Design
+
+- Keep modules cohesive and single-purpose.
+- Favor pure functions in core logic.
+- Use interfaces/types to describe contracts; avoid inheritance-heavy trees.
+
+## 3. Error Strategy
+
+- Use typed/domain error classes or discriminated unions.
+- Preserve cause/context when rethrowing.
+- Convert errors at boundaries (HTTP, queue, UI).
+
+## 4. Performance
+
+- Measure before optimization.
+- Reduce allocations/churn in hot loops.
+- Use streaming/iterative processing for large payloads.
+- Watch serialization/deserialization costs.
+
+## 5. Tooling Baseline
+
+- Format: `prettier`.
+- Lint: `eslint` with strict rules.
+- Typecheck: `tsc --noEmit`.
+- Tests: unit + integration (Jest/Vitest/Playwright as relevant).
+
+## 6. Anti-Patterns
+
+- Implicit `any` spread.
+- Runtime assumptions without validation.
+- Catch-all errors without typed handling.
+- Shared mutable singleton state across modules.

--- a/skills/public/typescript-javascript-coding-patterns/references/domain-cli.md
+++ b/skills/public/typescript-javascript-coding-patterns/references/domain-cli.md
@@ -1,0 +1,6 @@
+# Domain Constraints: JS/TS CLI
+
+- Stable exit codes and output formats.
+- Avoid hidden global mutable state.
+- Keep command handlers composable and testable.
+- Fail fast on invalid input with actionable messages.

--- a/skills/public/typescript-javascript-coding-patterns/references/domain-frontend.md
+++ b/skills/public/typescript-javascript-coding-patterns/references/domain-frontend.md
@@ -1,0 +1,6 @@
+# Domain Constraints: Frontend/Browser
+
+- Keep state transitions explicit and testable.
+- Handle loading/error/empty states deterministically.
+- Prevent race conditions in async UI fetches (abort stale requests).
+- Keep bundle impact in mind for dependency additions.

--- a/skills/public/typescript-javascript-coding-patterns/references/domain-web.md
+++ b/skills/public/typescript-javascript-coding-patterns/references/domain-web.md
@@ -1,0 +1,7 @@
+# Domain Constraints: JS/TS Web APIs
+
+- Enforce request schema validation.
+- Use explicit timeout + retry policy for downstream calls.
+- Return stable error shapes.
+- Attach correlation IDs in logs and traces.
+- Bound concurrent upstream/downstream operations.

--- a/skills/public/typescript-javascript-coding-patterns/references/error-to-design-map.md
+++ b/skills/public/typescript-javascript-coding-patterns/references/error-to-design-map.md
@@ -1,0 +1,16 @@
+# Error-to-Design Map (JS/TS)
+
+## Type and Contract Failures
+
+- Frequent type assertions (`as Foo`) to force code to compile -> weak model boundaries; introduce runtime validation and tighter types.
+- Repeated `undefined` access failures -> optionality unmanaged; explicit narrowing and defaults needed.
+
+## Async Failures
+
+- Unhandled promise rejections -> unsupervised async tasks; centralize task orchestration.
+- Timeout and retry chaos -> no unified policy; create shared resilience utilities.
+
+## Runtime Bugs
+
+- “Works in dev, fails in prod” serialization/input issues -> missing boundary validation.
+- Memory growth under load -> unbounded concurrency/queues; enforce limits and backpressure.

--- a/skills/public/typescript-javascript-coding-patterns/references/review-checklist.md
+++ b/skills/public/typescript-javascript-coding-patterns/references/review-checklist.md
@@ -1,0 +1,22 @@
+# JS/TS Review Checklist
+
+## Severity
+
+- `S0`: security/data-loss/outage risk.
+- `S1`: correctness bug.
+- `S2`: maintainability/performance risk.
+- `S3`: style/docs.
+
+## Findings-First Format
+
+1. List findings by severity with file/line.
+2. Explain impact and trigger conditions.
+3. Recommend minimal fix.
+4. Then note missing tests.
+
+## Checks
+
+- Input boundaries validated (not trusted by default).
+- Async paths bounded, cancellable, and error-aware.
+- Type contracts are explicit and not bypassed with unsafe assertions.
+- Tests cover unhappy paths and concurrency/resource edge cases.


### PR DESCRIPTION
Add agent configs and reference guides for Go, Python, Rust, and TS/JS coding-pattern skills, plus skill-development reference material.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive coding pattern guides for Go, Python, Rust, and TypeScript/JavaScript covering core practices, async patterns, domain constraints, and error remediation strategies.
  * Introduced standardized code review checklists across all languages with severity levels and structured findings formats.
  * Added skill development methodology guide for creating reusable coding pattern resources.

* **New Features**
  * Integrated OpenAI agent configurations for all coding pattern skill domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->