### PR TITLE
docs(plan): add fan-out roadmap and tracking

### DIFF
--- a/SUBAGENT_TODO.md
+++ b/SUBAGENT_TODO.md
@@ -1,6 +1,6 @@
 # SUBAGENT TODO
 
-Purpose: Subagent ownership map for WASM rollout tasks in `TODO.md` (`WS*`).
+Purpose: Scratchpad for active subagent assignments.
 
 ## Status values
 
@@ -9,22 +9,13 @@ Purpose: Subagent ownership map for WASM rollout tasks in `TODO.md` (`WS*`).
 - `completed`
 - `blocked`
 
-## Active assignments
+## Scratchpad assignments
 
 | Parent TODO | Subagent | Scope | Why | Expected Outcome | Status | Notes |
 |---|---|---|---|---|---|---|
-| WS0 | SA-Contract-Parity | Shared TS/Rust API contracts, compatibility matrix, migration notes | Prevent API drift before implementation starts | Signed-off parity spec with explicit browser exceptions | completed | Added preview contract in `docs/BINDINGS_WASM.md` with locked browser differences and migration constraints |
-| WS1 | SA-WASM-Packaging | WASM binding package scaffold, loader/init, npm publish config | Browser runtime needs installable package equivalent to Node binding | `simple-agents-wasm` package scaffold with build/release pipeline draft | completed | Added `bindings/wasm/simple-agents-wasm` package with `package.json`, typed exports, and runtime implementation scaffold |
-| WS2 | SA-WASM-Completion-Streaming | Completion + stream + streamEvents implementation in WASM binding | Core runtime value depends on LLM calls and streaming parity | Browser-capable completion/stream APIs with typed outputs and error mapping | completed | Rust-backed wasm client now serves completion + stream events via `wasm-bindgen`; healed/schema remains explicitly unsupported with typed errors |
-| WS3 | SA-WASM-Workflow-API | YAML workflow runner browser-safe API surface | Node path-based APIs are incompatible with browser sandbox | Add string/object workflow methods and explicit unsupported-path errors | completed | Implemented `runWorkflowYamlString` + `runWorkflowYaml` unsupported-path error behavior in wasm package |
-| WS4 | SA-Parity-Tests | Shared Node/WASM fixture tests and failure-mode coverage | "Near replica" claim must be measurable | Contract parity suite passing for result shape, usage, streaming events, and errors | pending | Reuse same fixtures across both bindings |
-| WS5 | SA-YamSLAM-Runtime-Adapter | YamSLAM runtime abstraction and progressive rollout wiring | Need zero-downtime switch from Node route to WASM-first | Adapter-based runtime selection with WASM default + Node fallback | pending | Keep `/api/complete` available until parity + deploy checks pass |
-| WS6 | SA-Browser-Security-DX | BYOK handling, redaction, error UX, CORS diagnostics | Browser mode increases user-facing failure modes | Safe logging/redaction and clear runtime error guidance in UI | pending | Verify no credential leakage in logs or telemetry payloads |
-| WS7 | SA-Deploy-Release | Vercel smoke tests, release checklist, cutover readiness | Deployment confidence is required before fallback removal | Preview deploy passes with WASM default; release checklist completed | pending | Reference `make-it-deploy-vercel-happen.md` for operational checks |
-| WS8 | SA-Docs-Cutover | Docs updates for package usage, migration, fallback policy | Users need clear implementation and upgrade guidance | Updated docs in `docs/` plus YamSLAM README/runtime notes | in_progress | Added docs map/index links and preview binding reference; YamSLAM runtime cutover docs still pending |
-
-## Coordination notes
-
-- Keep assignments non-overlapping; share contract artifacts from WS0 into WS1-WS5.
-- Any deviation from parity contract must update WS0 notes before merge.
-- WS5 should not remove Node fallback until WS4 and WS7 are completed.
+| NS8 | SA-Types-Contract | `crates/simple-agent-type/src/response.rs` and dependent types/tests | Canonical naming must be standardized at the shared usage type layer | Unified usage contracts expose `reasoning_tokens` (not `thinking_tokens`) | completed | Renamed usage contract; retained deserialize alias for legacy `thinking_tokens` |
+| NS9 | SA-Providers-Reasoning-Usage | `crates/simple-agents-providers/src/openai/*` plus provider tests | Provider parsing currently drops reasoning usage, causing null totals downstream | Response and streaming usage mapping sets `reasoning_tokens` when provider emits reasoning token detail fields | completed | Added OpenAI/OpenRouter mapping and provider tests for usage detail parsing |
+| NS9, NS10 | SA-Workflow-Nerdstats-Core | `crates/simple-agents-workflow/src/yaml_runner.rs` | Source-of-truth aggregation and nerdstats schema updates belong in Rust workflow core | Workflow totals include `total_reasoning_tokens`; `step_details` includes `model_name`; top-level `llm_node_models` removed | completed | Updated workflow aggregation, nerdstats payload, and yaml_runner tests |
+| NS11 | SA-Bindings-Go-Python | `bindings/go/simpleagents.go`, `examples/workflow_email/run_with_chat_history.py` | Consumer surfaces must align with renamed keys and per-step model attribution | Go/Python output and fallback paths use `reasoning_tokens` keys and `step_details[].model_name` | completed | Updated Go structs and Python fallback schema/logic |
+| NS12 | SA-Tests-Docs | Workflow/provider/binding tests and `docs/BINDINGS_PYTHON.md`, `PERFORMANCE.md` | Schema break must be protected by tests and reflected in docs | Assertions and docs reference `reasoning_tokens`/`total_reasoning_tokens`, and no `llm_node_models` | completed | Rust/provider tests and docs now match new contract |
+| NS13 | SA-E2E-Repro-Validation | Go chat-history example + trace inspection | Final verification should mirror user-reported reproduction path | `make run-go-chat-history` run confirms final nerdstats schema and reasoning-token totals behavior | completed | Verified output includes `step_details[].model_name` and `total_reasoning_tokens` key |

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # Active TODO
 
-Date: 2026-03-24
-Purpose: Deliver `simple-agents-wasm` with near-API parity to `simple-agents-node`, then integrate YamSLAM with WASM-first runtime and Node fallback during rollout.
+Date: 2026-03-10
+Purpose: Scratchpad for current execution tasks.
 
 ## Status values
 
@@ -10,37 +10,13 @@ Purpose: Deliver `simple-agents-wasm` with near-API parity to `simple-agents-nod
 - `completed`
 - `blocked`
 
-## Rollout decisions (locked)
-
-1. Keep `/api/complete` Node route as temporary fallback for one release while WASM path stabilizes.
-2. Browser workflow execution supports YAML string/object input only (no file path-based APIs in WASM).
-
-## Core constraints (applies to every task)
-
-1. Rust remains source-of-truth; WASM and Node bindings must reuse shared core behavior.
-2. Preserve public behavior unless change is intentional, documented, and parity-tested.
-3. Maintain explicit typed contracts and actionable errors across bindings.
-4. Add regression tests for success and failure paths for every behavior change.
-5. Do not leak secrets in logs, telemetry, or serialized payloads.
-
-## Master tasks
+## Scratchpad
 
 | ID | Task | Why this is needed | Expected outcome | Status |
 |---|---|---|---|---|
-| WS0 | Define parity contract and migration guardrails | WASM rollout needs clear compatibility targets before implementation | Versioned Node/WASM contract doc + migration rules + explicit non-parity exceptions approved | completed |
-| WS1 | Implement `simple-agents-wasm` package scaffold | Browser runtime cannot use N-API package directly | Publishable WASM package structure with loader, typed exports, and init flow | completed |
-| WS2 | Port completion + streaming APIs to WASM | Core LLM operations must match Node behavior | `Client.complete`, `Client.stream`, and `Client.streamEvents` function in browser with typed outputs | completed |
-| WS3 | Add browser-safe workflow execution APIs | Node path-based workflow APIs do not map to browser | `runWorkflowYamlString`/object-based workflow methods with explicit errors for path-only calls | completed |
-| WS4 | Build Node/WASM parity test suite | Near-replica claim must be enforced by tests | Shared fixtures verify response/event/type parity and document acceptable differences | pending |
-| WS5 | Integrate YamSLAM runtime adapter (WASM-first, Node fallback) | YamSLAM needs safe staged migration without breaking active users | Runtime selector defaults to WASM with opt-in or auto fallback to `/api/complete` route | pending |
-| WS6 | Security and DX hardening for browser BYOK | Browser runtime increases CORS and credential UX concerns | Redaction-safe logs, clear CORS/auth errors, and documented BYOK handling guarantees | pending |
-| WS7 | Deployability and release automation | Vercel deployment currently blocked by platform-specific native binary limits | WASM package release + YamSLAM deploy checklist pass + smoke tests green on Vercel preview | pending |
-| WS8 | Documentation and cutover plan | Users need adoption guidance and rollback path | Updated docs for WASM usage, fallback policy, known constraints, and final cutover steps | in_progress |
-
-## Technical notes
-
-- Keep `simple-agents-node` as server runtime fallback until WS4+WS7 pass and preview deployments are stable.
-- Keep browser API key handling explicit: forwarded only to target provider in WASM mode; if fallback is enabled, forwarded per-request to server runtime.
-- Do not expose file-system based workflow helpers in browser-facing APIs.
-- Prefer one adapter layer in YamSLAM (`runtime: "wasm" | "node"`) to avoid split logic throughout UI code.
-- Add parity-focused fixtures once and reuse them in Node + WASM test layers.
+| NS8 | Rename telemetry keys to `reasoning_tokens` | We are standardizing on reasoning terminology and removing `thinking_tokens` naming drift | All workflow/provider/binding outputs use `reasoning_tokens` and `total_reasoning_tokens`; no `thinking_tokens` keys remain | completed |
+| NS9 | Propagate provider reasoning usage into workflow metrics | Reasoning token counts are currently dropped in usage flow, causing null totals despite reasoning stream deltas | Provider response/stream-final usage populates `reasoning_tokens` and workflow totals aggregate it | completed |
+| NS10 | Move model attribution into `step_details` and remove `llm_node_models` | Nerdstats contract should attribute models per step instead of maintaining a separate top-level map | Every `llm_call` entry in `step_details` includes `model_name`; top-level `llm_node_models` is removed | completed |
+| NS11 | Align Go and Python consumers with new nerdstats contract | Bindings/examples must decode renamed token fields and new per-step model field | Go structs and Python fallback paths emit/consume `reasoning_tokens`, `total_reasoning_tokens`, and `step_details[].model_name` | completed |
+| NS12 | Refresh tests and docs for the schema break | Contract changes need regression coverage and documentation parity across surfaces | Rust/provider/binding tests and docs assert new keys and remove stale `thinking_tokens`/`llm_node_models` references | completed |
+| NS13 | Verify end-to-end via `make run-go-chat-history` | Fix must be validated in the exact user-reported workflow path | Repro run shows expected nerdstats schema and reasoning totals key (`total_reasoning_tokens`), non-null when provider usage includes reasoning data | completed |

--- a/fan_out_plan.md
+++ b/fan_out_plan.md
@@ -1,0 +1,124 @@
+# Fan-Out / Guardrail Future Plan
+
+## Goal
+
+Add first-class YAML support for fan-out DAG patterns (parallel + merge) while preserving backward compatibility, deterministic behavior, and cross-language parity.
+
+## Current State
+
+- YAML currently supports `llm_call`, `switch`, and `custom_worker` nodes.
+- Canonical IR/runtime already supports advanced DAG nodes (`parallel`, `merge`, `map`, `reduce`, `subgraph`, etc.) with bounded concurrency.
+- Runtime security controls already include fan-out limits (`max_parallel_branches`) and scope/payload guards.
+
+## Target Outcome
+
+Enable this pattern directly in YAML:
+
+1. Run guardrail policy checks deterministically.
+2. Fan out to parallel LLM/tool retrieval branches.
+3. Merge branch outputs with explicit merge policy.
+4. Run final synthesis over consolidated context.
+
+## Primary Risks
+
+1. **Execution path drift**  
+   Adding new YAML node types may route more workflows through IR runtime and change subtle behavior compared to fallback YAML execution.
+
+2. **State shape drift**  
+   Differences in output/global-memory handling across YAML execution paths can break downstream switch conditions.
+
+3. **Concurrency nondeterminism**  
+   Branch completion order can vary; implicit ordering assumptions in consumers may produce flaky outcomes.
+
+4. **Unsupported branch behavior**  
+   Parallel branch execution currently supports only `llm`/`tool` branch node kinds in runtime internals.
+
+5. **Throughput and cost spikes**  
+   Fan-out can increase token, latency, and provider rate-limit pressure if limits/policies are not enforced consistently.
+
+6. **Telemetry contract changes**  
+   Existing event consumers may assume mostly linear node progression; interleaved branch events may break dashboards/parsers.
+
+7. **Binding parity risk**  
+   Rust/Node/Python/Go may diverge unless YAML node-surface and result contracts are rolled out together.
+
+## Potential Breaking Points
+
+- YAML verification not updated for new node schemas (`parallel`, `merge`) causing late runtime failures.
+- Invalid merge wiring (`sources`, `policy`, `quorum`) that passes authoring but fails at runtime.
+- Changes in terminal output shape from merged branch outputs impacting existing downstream prompt templates.
+- Cross-language wrappers relying on old YAML taxonomy or old error messages.
+- Replay/debug tooling assuming linear traces, not branch-level fan-out/merge paths.
+
+## Safe Rollout Plan
+
+### Phase 1: Contract + Validation (No behavior change)
+
+- Extend YAML schema/types to include `parallel` and `merge` nodes.
+- Extend YAML verifier with strict checks:
+  - branch/source IDs must exist
+  - `parallel.max_in_flight >= 1`
+  - `merge.policy` valid
+  - `merge.quorum` only valid for `quorum` policy and within source bounds
+- Keep behind feature flag.
+
+### Phase 2: IR Mapping + Runtime Wiring
+
+- Map YAML `parallel`/`merge` to canonical IR `NodeKind::Parallel` / `NodeKind::Merge`.
+- Preserve deterministic output ordering (stable branch/source order).
+- Enforce runtime limits (`max_parallel_branches`, scheduler bounds, timeouts/retries).
+
+### Phase 3: Guardrail-First Pattern
+
+- Add recommended pattern documentation:
+  - classify/intent
+  - deterministic guardrail worker
+  - allow/deny switch
+  - parallel retrieval branches
+  - merge
+  - final synthesis
+- Keep policy-sensitive checks in deterministic workers, not probabilistic LLM-only paths.
+
+### Phase 4: Observability + Debugging Stability
+
+- Add explicit branch lifecycle events (branch start/complete/fail).
+- Keep existing top-level event fields stable for backward compatibility.
+- Validate replay and timeline tooling against fan-out workflows.
+
+### Phase 5: Cross-Language Parity + Examples
+
+- Add/refresh examples demonstrating guardrail + parallel retrieval + merge.
+- Ensure Node/Python/Go wrappers expose identical behavior and errors.
+- Add parity fixtures and contract tests for YAML fan-out workflows.
+
+## Test Strategy
+
+1. **Validation tests**: malformed branch/source/quorum cases hard-fail early.
+2. **Runtime tests**: successful fan-out + merge with deterministic merged output.
+3. **Security tests**: fan-out limits and expression scope limits enforced.
+4. **Retry/timeout tests**: branch-level failure and recovery behavior.
+5. **Replay tests**: branch traces remain structurally valid and deterministic.
+6. **Binding tests**: same workflow fixture yields equivalent outputs across languages.
+
+## Backward Compatibility Rules
+
+- Existing YAML workflows must run unchanged.
+- New node types are additive only.
+- Existing event/output fields remain stable; new branch metadata is additive.
+- Error codes/messages for old paths should not regress.
+
+## Rollback Strategy
+
+- Feature flag controls rollout.
+- If regression is detected, disable fan-out YAML nodes while retaining IR/runtime internals.
+- Keep fallback execution path operational for non-fan-out workflows.
+
+## Recommended First Deliverable
+
+Implement a minimal, safe v1:
+
+- YAML `parallel` + `merge` support
+- strict validation
+- deterministic merge semantics
+- bounded concurrency/security enforcement
+- one canonical example + one end-to-end parity fixture


### PR DESCRIPTION
Capture the fan-out guardrail roadmap alongside TODO tracking so future work has clear phases, risks, and validation strategy.